### PR TITLE
Minor cleanups and type strictening

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -90,7 +90,7 @@ fn reset_flag(flag: TargetFlag, state: CpuState) -> CpuState {
 // lb means "left byte", rb means "right byte"
 
 // (left and right is used instead of high and low in order to
-// prevent confusing it when dealing with different endiannesses)
+// prevent confusion when dealing with different endiannesses)
 
 fn get_lb(value: u16) -> u8 {
     (value >> 8) as u8

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -108,18 +108,12 @@ fn set_rb(value: u16, rb_val: u8) -> u16 {
     value & !0xFF | rb_val as u16
 }
 
-fn set_bit(value: u16, bit: u8) -> u16 {
-    
-    let mut result = value;
-    result |= 1 << bit;
-    result
+fn set_bit(value: u16, offset: u8) -> u16 {
+    value | 1 << offset
 }
 
-fn reset_bit(value: u16, bit: u8) -> u16 {
-    
-    let mut result = value;
-    result &= !(1 << bit);
-    result
+fn reset_bit(value: u16, offset: u8) -> u16 {
+    value & !(1 << offset)
 }
 
 pub fn init_cpu(rom: Vec<u8>) {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -86,6 +86,12 @@ fn reset_flag(flag: TargetFlag, state: CpuState) -> CpuState {
     result_state
 }
 
+// assuming 16 bit values is all we ever deal with
+// lb means "left byte", rb means "right byte"
+
+// (left and right is used instead of high and low in order to
+// prevent confusing it when dealing with different endiannesses)
+
 fn get_lb(value: u16) -> u8 {
     (value >> 8) as u8
 }


### PR DESCRIPTION
This PR attempts to make the byte/bit-manipulation methods a bit leaner and to tighten up the types. Also removes some casts that are now unnecessary.

Shouldn't cause any functional changes / regressions, could use a quick test though, just to make sure. Also rip the git diff, them comments really messed with it's brain lol

Hope the new naming scheme won't clash too much with the previous one, though `get_lb` (get left byte) will be easy to confuse with `get_lower_byte` in the beginning for sure. You may revert it if you want to, though I unfortunately sent the rename and the code changes in one commit, so it might be a bit tedious. Sorry for that, it was a late thought.

I've tested each of the functions on Rust Playground, along with some extra ones that I decided not to commit. You can take a look [here](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=8cba6c0fd322404eb045347717dca308).

Cheers, and good luck with the project! :) :beers: 