### PR TITLE
Initial UI implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Cargo.lock
 .vscode/
 
 *.o
+*.gb
+imgui.ini

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,13 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-byteorder = "1.3.2"
+
+gl = "0.14.0"
 sdl2 = "0.32.2"
-simple_logger = "1.3.0"
+imgui = "0.2.1"
+imgui-sdl2 = "0.7.0"
+imgui-opengl-renderer = "0.6.0"
+
 log = "0.4.8"
+byteorder = "1.3.2"
+simple_logger = "1.3.0"

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -185,7 +185,6 @@ fn update_inputs(input_rx: &Receiver<InputEvent>, memory: &(Arc<Mutex<RomMemory>
         }
         else if input_value & 0x10 == 0x10 {
 
-            info!("Input: Pressed button at P14 row");
             match received_message {
                 InputEvent::APressed => { input_value = utils::reset_bit(input_value, 0); should_interrupt = true; },
                 InputEvent::AReleased => { input_value = utils::set_bit(input_value, 0) },

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -94,8 +94,6 @@ pub fn cpu_loop(cycles: Arc<Mutex<u16>>, memory: (Arc<Mutex<RomMemory>>, Arc<Mut
     let mut timer_state = timer::init_timer();
 
     loop {
-
-        if current_state.cycles.get() > 200 {current_state.cycles.set(0)}
         
         handle_interrupts(&mut current_state, &memory);
         let mut opcode = memory::cpu_read(current_state.pc.get(), &memory);

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -88,7 +88,7 @@ pub fn init_cpu() -> CpuState {
     initial_state
 }
 
-pub fn cpu_loop(cycles: Arc<Mutex<u16>>, memory: (Arc<Mutex<RomMemory>>, Arc<Mutex<CpuMemory>>, Arc<Mutex<GpuMemory>>)) {
+pub fn cpu_loop(cycles: Arc<Mutex<u16>>, memory: (Arc<Mutex<RomMemory>>, Arc<Mutex<CpuMemory>>, Arc<Mutex<GpuMemory>>), input: Receiver<InputEvent>) {
 
     let mut current_state = init_cpu();
     let mut timer_state = timer::init_timer();
@@ -139,7 +139,7 @@ pub fn cpu_loop(cycles: Arc<Mutex<u16>>, memory: (Arc<Mutex<RomMemory>>, Arc<Mut
         let mut cyc_mut = cycles.lock().unwrap();
         *cyc_mut = cyc_mut.overflowing_add(current_state.cycles.get()).0;
         timer::timer_cycle(&mut timer_state, current_state.cycles.get(), &memory.1);
-        //if update_inputs(&input, &memory) {break}
+        if update_inputs(&input, &memory) {break}
     }
 }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -172,16 +172,15 @@ fn update_inputs(input_rx: &Receiver<InputEvent>, memory: &(Arc<Mutex<RomMemory>
         }
         else if input_value & 0x20 == 0x20 {
 
-            info!("Input: Pressed button at P15 row");
             match received_message {
-                InputEvent::RightPressed => { input_value = utils::set_bit(input_value, 0); should_interrupt = true; },
-                InputEvent::RightReleased => { input_value = utils::reset_bit(input_value, 0); },
-                InputEvent::LeftPressed => { input_value = utils::set_bit(input_value, 1); should_interrupt = true; },
-                InputEvent::LeftReleased => { input_value = utils::reset_bit(input_value, 1); },
-                InputEvent::UpPressed => { input_value = utils::set_bit(input_value, 2); should_interrupt = true; },
-                InputEvent::UpReleased => { input_value = utils::reset_bit(input_value, 2); },
-                InputEvent::DownPressed => { input_value = utils::set_bit(input_value, 3); should_interrupt = true; },
-                InputEvent::DownReleased => { input_value = utils::reset_bit(input_value, 3); },
+                InputEvent::RightPressed => { input_value = utils::reset_bit(input_value, 0); should_interrupt = true; },
+                InputEvent::RightReleased => { input_value = utils::set_bit(input_value, 0); },
+                InputEvent::LeftPressed => { input_value = utils::reset_bit(input_value, 1); should_interrupt = true; },
+                InputEvent::LeftReleased => { input_value = utils::set_bit(input_value, 1); },
+                InputEvent::UpPressed => { input_value = utils::reset_bit(input_value, 2); should_interrupt = true; },
+                InputEvent::UpReleased => { input_value = utils::set_bit(input_value, 2); },
+                InputEvent::DownPressed => { input_value = utils::reset_bit(input_value, 3); should_interrupt = true; },
+                InputEvent::DownReleased => { input_value = utils::set_bit(input_value, 3); },
                 _ => {}
             }
 
@@ -190,14 +189,14 @@ fn update_inputs(input_rx: &Receiver<InputEvent>, memory: &(Arc<Mutex<RomMemory>
 
             info!("Input: Pressed button at P14 row");
             match received_message {
-                InputEvent::APressed => { input_value = utils::set_bit(input_value, 0); should_interrupt = true; },
-                InputEvent::AReleased => { input_value = utils::reset_bit(input_value, 0) },
-                InputEvent::BPressed => { input_value = utils::set_bit(input_value, 1); should_interrupt = true; },
-                InputEvent::BReleased => { input_value = utils::reset_bit(input_value, 1) },
-                InputEvent::SelectPressed => { input_value = utils::set_bit(input_value, 2); should_interrupt = true; },
-                InputEvent::SelectReleased => { input_value = utils::reset_bit(input_value, 2) },
-                InputEvent::StartPressed => { input_value = utils::set_bit(input_value, 3); should_interrupt = true; },
-                InputEvent::StartReleased => { input_value = utils::reset_bit(input_value, 3) },
+                InputEvent::APressed => { input_value = utils::reset_bit(input_value, 0); should_interrupt = true; },
+                InputEvent::AReleased => { input_value = utils::set_bit(input_value, 0) },
+                InputEvent::BPressed => { input_value = utils::reset_bit(input_value, 1); should_interrupt = true; },
+                InputEvent::BReleased => { input_value = utils::set_bit(input_value, 1) },
+                InputEvent::SelectPressed => { input_value = utils::reset_bit(input_value, 2); should_interrupt = true; },
+                InputEvent::SelectReleased => { input_value = utils::set_bit(input_value, 2) },
+                InputEvent::StartPressed => { input_value = utils::reset_bit(input_value, 3); should_interrupt = true; },
+                InputEvent::StartReleased => { input_value = utils::set_bit(input_value, 3) },
                 _ => {}
             }
         }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -88,7 +88,7 @@ pub fn init_cpu() -> CpuState {
     initial_state
 }
 
-pub fn cpu_loop(cycles: Arc<Mutex<u16>>, input: Receiver<InputEvent>, memory: (Arc<Mutex<RomMemory>>, Arc<Mutex<CpuMemory>>, Arc<Mutex<GpuMemory>>)) {
+pub fn cpu_loop(cycles: Arc<Mutex<u16>>, memory: (Arc<Mutex<RomMemory>>, Arc<Mutex<CpuMemory>>, Arc<Mutex<GpuMemory>>)) {
 
     let mut current_state = init_cpu();
     let mut timer_state = timer::init_timer();
@@ -139,7 +139,7 @@ pub fn cpu_loop(cycles: Arc<Mutex<u16>>, input: Receiver<InputEvent>, memory: (A
         let mut cyc_mut = cycles.lock().unwrap();
         *cyc_mut = cyc_mut.overflowing_add(current_state.cycles.get()).0;
         timer::timer_cycle(&mut timer_state, current_state.cycles.get(), &memory.1);
-        if update_inputs(&input, &memory) {break}
+        //if update_inputs(&input, &memory) {break}
     }
 }
 

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -83,13 +83,13 @@ pub fn initialize(path: &PathBuf) -> EmuInit {
     }
 }
 
-pub fn start_emulation(arcs: &EmuInit) {
+pub fn start_emulation(arcs: &EmuInit, input: Receiver<InputEvent>) {
         
     let cpu_cycles = Arc::clone(&arcs.cycles_arc);
     let cpu_arc = (Arc::clone(&arcs.cpu.0), Arc::clone(&arcs.cpu.1), Arc::clone(&arcs.cpu.2));
 
     let _cpu_thread = thread::Builder::new().name("cpu_thread".to_string()).spawn(move || {
-        cpu::cpu_loop(cpu_cycles, cpu_arc);
+        cpu::cpu_loop(cpu_cycles, cpu_arc, input);
     }).unwrap();
 
     info!("Emu: Stopped emulation.");

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -173,7 +173,8 @@ fn lcd_transfer_mode(state: &mut GpuState, memory: &(Arc<Mutex<CpuMemory>>, Arc<
         state.tiles_dirty = false;
         state.bg_dirty = true;
     }
-    if state.bg_dirty {
+    if state.bg_dirty && state.all_tiles.len() != 0 {
+        make_tiles(state, memory);
         make_background(state, memory);
         state.bg_dirty = false;
     }

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -277,67 +277,32 @@ fn make_background(state: &mut GpuState, memory: &(Arc<Mutex<CpuMemory>>, Arc<Mu
 
     let mut generated_lines: u16 = 0;
     let mut new_points: Vec<BGPoint> = Vec::new();
-    let signed_mode = utils::check_bit(memory::gpu_read(0xFF40, memory), 3);
-
+    let mut current_background = if utils::check_bit(memory::gpu_read(0xFF40, memory), 3) {0x9C00} else {0x9800};
     
     info!("GPU: Regenerating background cache");
-
-    if signed_mode {
-
-        let mut current_background = 0x9C00;
     
-        while generated_lines < 256 {
+    while generated_lines < 256 {
 
-            let mut tiles: Vec<&Tile> = Vec::new();
-            let mut tile_idx: usize = 0;
+        let mut tiles: Vec<&Tile> = Vec::new();
+        let mut tile_idx: usize = 0;
 
-            // Loads tile indexes from memory, then gets the tile from GPU State and saves it to tiles.
-            // 32 tiles is the maximum amount of tiles per line in the background.
-            while tiles.len() < 32 {
+        // Loads tile indexes from memory, then gets the tile from GPU State and saves it to tiles.
+        // 32 tiles is the maximum amount of tiles per line in the background.
+        while tiles.len() < 32 {
 
-                let target_tile = memory::gpu_read(current_background, memory) as i8;
-                tiles.insert(tile_idx, &state.all_tiles[target_tile as usize]);
-                tile_idx += 1;
-                current_background += 1;
-            }
-
-            let mut tile_line = 0;
-
-            while tile_line < 8 {
-
-                new_points.append(&mut make_background_line(&tiles, tile_line, generated_lines as u8));
-                tile_line += 1;
-                generated_lines += 1;
-            }
+            let target_tile = memory::gpu_read(current_background, memory) as i8;
+            tiles.insert(tile_idx, &state.all_tiles[target_tile as usize]);
+            tile_idx += 1;
+            current_background += 1;
         }
-    }
-    else {
 
-        let mut current_background = 0x9800;
-    
-        while generated_lines < 256 {
+        let mut tile_line = 0;
 
-            let mut tiles: Vec<&Tile> = Vec::new();
-            let mut tile_idx: usize = 0;
+        while tile_line < 8 {
 
-            // Loads tile indexes from memory, then gets the tile from GPU State and saves it to tiles.
-            // 32 tiles is the maximum amount of tiles per line in the background.
-            while tiles.len() < 32 {
-
-                let target_tile = memory::gpu_read(current_background, memory);
-                tiles.insert(tile_idx, &state.all_tiles[target_tile as usize]);
-                tile_idx += 1;
-                current_background += 1;
-            }
-
-            let mut tile_line = 0;
-
-            while tile_line < 8 {
-
-                new_points.append(&mut make_background_line(&tiles, tile_line, generated_lines as u8));
-                tile_line += 1;
-                generated_lines += 1;
-            }
+            new_points.append(&mut make_background_line(&tiles, tile_line, generated_lines as u8));
+            tile_line += 1;
+            generated_lines += 1;
         }
     }
 

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -94,7 +94,6 @@ fn hblank_mode(state: &mut GpuState, canvas: &mut Canvas<Window>, memory: &(Arc<
     stat_value = utils::reset_bit(stat_value, 0);
     memory::gpu_write(0xFF41, stat_value, memory);
 
-
     if state.all_tiles.len() >= 128 && state.background_points.len() >= 65536 {
         draw(state, canvas, memory);
     }
@@ -190,11 +189,9 @@ fn draw(state: &mut GpuState, canvas: &mut Canvas<Window>, memory: &(Arc<Mutex<C
     let mut drawn_pixels: u16 = 0;
 
     // Index offset for the points array in case the current line is not 0.
-    if state.line > 0 {
-        point_idx += 256 * state.line as u16;
-    }
+    point_idx += 256 * state.line as u16;
 
-    // Draw a whole line from the background map, skipping points that are outside the screen.
+    // Draw a whole line from the background map.
     while drawn_pixels < 256 {
 
         let current_point = &state.background_points[point_idx as usize];

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,18 +1,14 @@
 use std::ops::Neg;
 use std::sync::{Arc, Mutex};
-use std::sync::mpsc::Sender;
 
 use log::info;
 
 use sdl2::rect::Point;
-use sdl2::event::Event;
 use sdl2::video::Window;
 use sdl2::pixels::Color;
 use sdl2::render::Canvas;
-use sdl2::keyboard::Keycode;
 
 use super::utils;
-use super::emulator::InputEvent;
 use super::memory;
 use super::memory::{CpuMemory, GpuMemory};
 
@@ -40,9 +36,9 @@ pub struct GpuState {
     pub tiles_dirty: bool,
 }
 
-pub fn start_gpu(cycles: Arc<Mutex<u16>>, input: Sender<InputEvent>, memory: (Arc<Mutex<CpuMemory>>, Arc<Mutex<GpuMemory>>)) {
+pub fn init_gpu() -> GpuState {
 
-    let mut current_state = GpuState {
+    GpuState {
         gpu_mode: 0,
         gpu_cycles: 0,
         line: 0,
@@ -50,78 +46,41 @@ pub fn start_gpu(cycles: Arc<Mutex<u16>>, input: Sender<InputEvent>, memory: (Ar
         background_points: Vec::new(),
         bg_dirty: false,
         tiles_dirty: false,
-    };
-        
-    let sdl_ctx = sdl2::init().unwrap();
-    let sdl_video = sdl_ctx.video().unwrap();
-    let mut sdl_events = sdl_ctx.event_pump().unwrap();
-    let emu_window = sdl_video.window("Rusty Boi", 160 * 3, 144 * 3).position_centered().build().unwrap();
-    let mut emu_canvas = emu_window.into_canvas().present_vsync().build().unwrap();
+    }
+}
 
-    // TODO: Add a way to change scaling without having to change it from code.
-    // Maybe as an argument, or request a scale multiplier after loading the ROMs.
-    emu_canvas.set_scale(3.0, 3.0).unwrap();
-    emu_canvas.set_draw_color(Color::RGB(255, 255, 255));
-    emu_canvas.clear();
-    emu_canvas.present();
+pub fn gpu_loop(cycles: &Arc<Mutex<u16>>, state: &mut GpuState, canvas: &mut Canvas<Window>, memory: &(Arc<Mutex<CpuMemory>>, Arc<Mutex<GpuMemory>>)) {
 
-    loop {
+    let lcdc_stat = memory::gpu_read(0xFF40, &memory);
+    let display_enabled = utils::check_bit(lcdc_stat, 7);
 
-        for event in sdl_events.poll_iter() {
+    let mem = memory.1.lock().unwrap();
+    state.bg_dirty = mem.background_dirty;
+    state.tiles_dirty = mem.tiles_dirty;
+    std::mem::drop(mem);
 
-            match event {
-                Event::Quit {..} => { input.send(InputEvent::Quit).unwrap() },
-                Event::KeyDown { keycode: Some(Keycode::A), .. } => { input.send(InputEvent::APressed).unwrap() },
-                Event::KeyUp  { keycode: Some(Keycode::A), .. } => { input.send(InputEvent::AReleased).unwrap() },
-                Event::KeyDown { keycode: Some(Keycode::S), .. } => { input.send(InputEvent::BPressed).unwrap() },
-                Event::KeyUp  { keycode: Some(Keycode::S), .. } => { input.send(InputEvent::BReleased).unwrap() },
-                Event::KeyDown { keycode: Some(Keycode::Up), .. } => { input.send(InputEvent::UpPressed).unwrap() },
-                Event::KeyUp  { keycode: Some(Keycode::Up), .. } => { input.send(InputEvent::UpReleased).unwrap() },
-                Event::KeyDown { keycode: Some(Keycode::Left), .. } => { input.send(InputEvent::LeftPressed).unwrap() },
-                Event::KeyUp  { keycode: Some(Keycode::Left), .. } => { input.send(InputEvent::LeftReleased).unwrap() },
-                Event::KeyDown { keycode: Some(Keycode::Right), .. } => { input.send(InputEvent::RightPressed).unwrap() },
-                Event::KeyUp  { keycode: Some(Keycode::Right), .. } => { input.send(InputEvent::RightReleased).unwrap() },
-                Event::KeyDown { keycode: Some(Keycode::Down), .. } => { input.send(InputEvent::DownPressed).unwrap() },
-                Event::KeyUp  { keycode: Some(Keycode::Down), .. } => { input.send(InputEvent::DownReleased).unwrap() },
-                Event::KeyDown { keycode: Some(Keycode::Return), .. } => { input.send(InputEvent::StartPressed).unwrap() },
-                Event::KeyUp  { keycode: Some(Keycode::Return), .. } => { input.send(InputEvent::StartReleased).unwrap() },
-                Event::KeyDown { keycode: Some(Keycode::Backspace), .. } => { input.send(InputEvent::SelectPressed).unwrap() },
-                Event::KeyUp  { keycode: Some(Keycode::Backspace), .. } => { input.send(InputEvent::SelectReleased).unwrap() },
-                _ => {}
-            }
+    let cyc_mut = cycles.lock().unwrap();
+    state.gpu_cycles = state.gpu_cycles.overflowing_add(*cyc_mut).0;
+    std::mem::drop(cyc_mut);
+
+    if display_enabled {
+
+        if state.gpu_mode == 0 && state.gpu_cycles >= 204 {
+            hblank_mode(state, canvas, &memory);
+        }
+        else if state.gpu_mode == 1 && state.gpu_cycles >= 456 {
+            vblank_mode(state, canvas, &memory);
+        }
+        else if state.gpu_mode == 2 && state.gpu_cycles >= 80 {
+            oam_scan_mode(state, &memory);
+        }
+        else if state.gpu_mode == 3 && state.gpu_cycles >= 172 {
+            lcd_transfer_mode(state, &memory);
+            let mut mem = memory.1.lock().unwrap();
+            mem.background_dirty = false;
+            mem.tiles_dirty = false;
         }
 
-        let lcdc_stat = memory::gpu_read(0xFF40, &memory);
-        let display_enabled = utils::check_bit(lcdc_stat, 7);
-
-        let mem = memory.1.lock().unwrap();
-        current_state.bg_dirty = mem.background_dirty;
-        current_state.tiles_dirty = mem.tiles_dirty;
-        std::mem::drop(mem);
-
-        let cyc_mut = cycles.lock().unwrap();
-        current_state.gpu_cycles = current_state.gpu_cycles.overflowing_add(*cyc_mut).0;
-        std::mem::drop(cyc_mut);
-
-        if display_enabled {
-
-            if current_state.gpu_mode == 0 && current_state.gpu_cycles >= 204 {
-                hblank_mode(&mut current_state, &mut emu_canvas, &memory);
-            }
-            else if current_state.gpu_mode == 1 && current_state.gpu_cycles >= 456 {
-                vblank_mode(&mut current_state, &mut emu_canvas, &memory);
-            }
-            else if current_state.gpu_mode == 2 && current_state.gpu_cycles >= 80 {
-                oam_scan_mode(&mut current_state, &memory);
-            }
-            else if current_state.gpu_mode == 3 && current_state.gpu_cycles >= 172 {
-                lcd_transfer_mode(&mut current_state, &memory);
-                let mut mem = memory.1.lock().unwrap();
-                mem.background_dirty = false;
-                mem.tiles_dirty = false;
-            }
-
-        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,3 @@
-extern crate sdl2;
-extern crate log;
-extern crate simple_logger;
-
 mod cpu;
 mod gpu;
 mod timer;
@@ -14,11 +10,153 @@ mod emulator;
 mod opcodes;
 mod opcodes_prefixed;
 
+use emulator::init_emu;
+
 use log::info;
+use log::error;
+
+use sdl2::event::Event;
+
+use imgui::*;
+use imgui_sdl2;
+use imgui_opengl_renderer;
+
+use std::io;
+use std::fs;
+use std::path::Path;
+
 
 fn main() {
 
     simple_logger::init_with_level(log::Level::Info).unwrap();
     info!("Rusty Boi");
-    emulator::init_emu();
+
+    let sdl_ctx = sdl2::init().unwrap();
+    let sdl_video = sdl_ctx.video().unwrap();
+    let main_window = sdl_video.window("Rusty Boi", 600, 400).position_centered().opengl().build().unwrap();
+    let _gl_context = main_window.gl_create_context().expect("Failed to create OpenGL context");
+    gl::load_with(|s| sdl_video.gl_get_proc_address(s) as _);
+
+    let mut imgui = imgui::Context::create();
+    let mut sdl2_imgui = imgui_sdl2::ImguiSdl2::new(&mut imgui, &main_window);
+    let imgui_renderer = imgui_opengl_renderer::Renderer::new(&mut imgui, |s| sdl_video.gl_get_proc_address(s) as _);
+    let mut sdl_events = sdl_ctx.event_pump().unwrap();
+
+    let mut scale_factor = 1.0;
+    let all_roms = get_all_roms();
+    let mut _game_running = false;
+
+    'main: loop {
+
+        for event in sdl_events.poll_iter() {
+            
+            sdl2_imgui.handle_event(&mut imgui, &event);
+            if !sdl2_imgui.ignore_event(&event) {continue};
+
+            match event {
+                Event::Quit {..} => { break 'main },/*
+                Event::KeyDown { keycode: Some(Keycode::A), .. } => { input_tx.send(InputEvent::APressed).unwrap() },
+                Event::KeyUp  { keycode: Some(Keycode::A), .. } => { input_tx.send(InputEvent::AReleased).unwrap() },
+                Event::KeyDown { keycode: Some(Keycode::S), .. } => { input_tx.send(InputEvent::BPressed).unwrap() },
+                Event::KeyUp  { keycode: Some(Keycode::S), .. } => { input_tx.send(InputEvent::BReleased).unwrap() },
+                Event::KeyDown { keycode: Some(Keycode::Up), .. } => { input_tx.send(InputEvent::UpPressed).unwrap() },
+                Event::KeyUp  { keycode: Some(Keycode::Up), .. } => { input_tx.send(InputEvent::UpReleased).unwrap() },
+                Event::KeyDown { keycode: Some(Keycode::Left), .. } => { input_tx.send(InputEvent::LeftPressed).unwrap() },
+                Event::KeyUp  { keycode: Some(Keycode::Left), .. } => { input_tx.send(InputEvent::LeftReleased).unwrap() },
+                Event::KeyDown { keycode: Some(Keycode::Right), .. } => { input_tx.send(InputEvent::RightPressed).unwrap() },
+                Event::KeyUp  { keycode: Some(Keycode::Right), .. } => { input_tx.send(InputEvent::RightReleased).unwrap() },
+                Event::KeyDown { keycode: Some(Keycode::Down), .. } => { input_tx.send(InputEvent::DownPressed).unwrap() },
+                Event::KeyUp  { keycode: Some(Keycode::Down), .. } => { input_tx.send(InputEvent::DownReleased).unwrap() },
+                Event::KeyDown { keycode: Some(Keycode::Return), .. } => { input_tx.send(InputEvent::StartPressed).unwrap() },
+                Event::KeyUp  { keycode: Some(Keycode::Return), .. } => { input_tx.send(InputEvent::StartReleased).unwrap() },
+                Event::KeyDown { keycode: Some(Keycode::Backspace), .. } => { input_tx.send(InputEvent::SelectPressed).unwrap() },
+                Event::KeyUp  { keycode: Some(Keycode::Backspace), .. } => { input_tx.send(InputEvent::SelectReleased).unwrap() },*/
+                _ => {}
+            }
+        }
+
+        sdl2_imgui.prepare_frame(imgui.io_mut(), &main_window, &sdl_events.mouse_state());
+
+        let imgui_ui = imgui.frame();
+
+        Window::new(im_str!("Main Window"))
+        .size([300.0, 300.0], Condition::Always)
+        .build(&imgui_ui, || {
+            if let Some(menu) = imgui_ui.begin_menu(im_str!("Installed ROMs"), true) {
+                if all_roms.len() > 0 {
+
+                    for file in all_roms.iter() {
+                        let filename = ImString::new(file.file_name().into_string().unwrap());
+
+                        if MenuItem::new(&filename).build_with_ref(&imgui_ui, &mut false) { 
+
+                            if Path::new("Bootrom.gb").exists() {
+                                let game_window = sdl_video.window("Rusty Boi - Game Window", 160 * scale_factor as u32, 144 * scale_factor as u32)
+                                .position_centered().build().unwrap();
+                                let mut game_canvas = game_window.into_canvas().present_vsync().build().unwrap();
+                                game_canvas.set_scale(scale_factor, scale_factor).unwrap();
+                                init_emu(file);
+                            }
+                        };
+                    }
+                }
+                else {
+                    MenuItem::new(im_str!("No ROMs detected.")).build_with_ref(&imgui_ui, &mut false);
+                }
+                menu.end(&imgui_ui);
+            }
+            imgui_ui.separator();
+            if Path::new("Bootrom.gb").exists() {
+                imgui_ui.text_colored([0.0, 1.0, 0.0, 1.0], im_str!("Bootrom located, everything's ready"));
+            }
+            else {
+                imgui_ui.text_colored([1.0, 0.0, 0.0, 1.0], im_str!("Can't locate Bootrom!"));
+            }
+            imgui_ui.separator();
+            Slider::new(im_str!("Scale factor"), 1.0 ..= 50.0).display_format(im_str!("%.0f")).build(&imgui_ui, &mut scale_factor);
+        });
+
+        unsafe {
+            gl::ClearColor(0.2, 0.2, 0.2, 1.0);
+            gl::Clear(gl::COLOR_BUFFER_BIT);
+        }
+
+        sdl2_imgui.prepare_render(&imgui_ui, &main_window);
+        imgui_renderer.render(imgui_ui);
+        main_window.gl_swap_window();
+    }
+}
+
+fn get_all_roms() -> Vec<fs::DirEntry> {
+
+    init_dirs();
+    let mut all_roms: Vec<fs::DirEntry> = Vec::new();
+    
+    for entry in fs::read_dir("roms").unwrap() {
+        
+        let file = entry.unwrap();
+        let file_name = file.file_name().into_string().unwrap();
+        
+        if file_name.contains(".gb") {
+            all_roms.push(file);
+        }
+    }
+
+    all_roms
+}
+
+fn init_dirs() {
+
+    let roms_dir = fs::create_dir("roms");
+    match roms_dir {
+
+        Ok(_result) => {},
+        Err(error) => {
+            match error.kind() {
+                io::ErrorKind::AlreadyExists => {},
+                io::ErrorKind::PermissionDenied => {error!("Failed to create ROMs directory: Permission Denied")},
+                _ => {},
+            }
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,50 +3,29 @@ mod gpu;
 mod timer;
 mod memory;
 mod register;
-
+mod renderer;
 mod utils;
 mod emulator;
 
 mod opcodes;
 mod opcodes_prefixed;
 
-use emulator::init_emu;
-
 use log::info;
 use log::error;
 
-use sdl2::event::Event;
-
-use imgui::*;
-use imgui_sdl2;
-use imgui_opengl_renderer;
-
 use std::io;
 use std::fs;
-use std::path::Path;
 
 
 fn main() {
 
+    // Initialize the logger
     simple_logger::init_with_level(log::Level::Info).unwrap();
     info!("Rusty Boi");
 
-    let sdl_ctx = sdl2::init().unwrap();
-    let sdl_video = sdl_ctx.video().unwrap();
-    let main_window = sdl_video.window("Rusty Boi", 600, 400).position_centered().opengl().build().unwrap();
-    let _gl_context = main_window.gl_create_context().expect("Failed to create OpenGL context");
-    gl::load_with(|s| sdl_video.gl_get_proc_address(s) as _);
+    renderer::init_renderer();
 
-    let mut imgui = imgui::Context::create();
-    let mut sdl2_imgui = imgui_sdl2::ImguiSdl2::new(&mut imgui, &main_window);
-    let imgui_renderer = imgui_opengl_renderer::Renderer::new(&mut imgui, |s| sdl_video.gl_get_proc_address(s) as _);
-    let mut sdl_events = sdl_ctx.event_pump().unwrap();
-
-    let mut scale_factor = 1.0;
-    let all_roms = get_all_roms();
-    let mut _game_running = false;
-
-    'main: loop {
+    /*'main: loop {
 
         for event in sdl_events.poll_iter() {
             
@@ -124,39 +103,5 @@ fn main() {
         sdl2_imgui.prepare_render(&imgui_ui, &main_window);
         imgui_renderer.render(imgui_ui);
         main_window.gl_swap_window();
-    }
-}
-
-fn get_all_roms() -> Vec<fs::DirEntry> {
-
-    init_dirs();
-    let mut all_roms: Vec<fs::DirEntry> = Vec::new();
-    
-    for entry in fs::read_dir("roms").unwrap() {
-        
-        let file = entry.unwrap();
-        let file_name = file.file_name().into_string().unwrap();
-        
-        if file_name.contains(".gb") {
-            all_roms.push(file);
-        }
-    }
-
-    all_roms
-}
-
-fn init_dirs() {
-
-    let roms_dir = fs::create_dir("roms");
-    match roms_dir {
-
-        Ok(_result) => {},
-        Err(error) => {
-            match error.kind() {
-                io::ErrorKind::AlreadyExists => {},
-                io::ErrorKind::PermissionDenied => {error!("Failed to create ROMs directory: Permission Denied")},
-                _ => {},
-            }
-        }
-    }
+    }*/
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,10 +11,6 @@ mod opcodes;
 mod opcodes_prefixed;
 
 use log::info;
-use log::error;
-
-use std::io;
-use std::fs;
 
 
 fn main() {
@@ -24,84 +20,4 @@ fn main() {
     info!("Rusty Boi");
 
     renderer::init_renderer();
-
-    /*'main: loop {
-
-        for event in sdl_events.poll_iter() {
-            
-            sdl2_imgui.handle_event(&mut imgui, &event);
-            if !sdl2_imgui.ignore_event(&event) {continue};
-
-            match event {
-                Event::Quit {..} => { break 'main },/*
-                Event::KeyDown { keycode: Some(Keycode::A), .. } => { input_tx.send(InputEvent::APressed).unwrap() },
-                Event::KeyUp  { keycode: Some(Keycode::A), .. } => { input_tx.send(InputEvent::AReleased).unwrap() },
-                Event::KeyDown { keycode: Some(Keycode::S), .. } => { input_tx.send(InputEvent::BPressed).unwrap() },
-                Event::KeyUp  { keycode: Some(Keycode::S), .. } => { input_tx.send(InputEvent::BReleased).unwrap() },
-                Event::KeyDown { keycode: Some(Keycode::Up), .. } => { input_tx.send(InputEvent::UpPressed).unwrap() },
-                Event::KeyUp  { keycode: Some(Keycode::Up), .. } => { input_tx.send(InputEvent::UpReleased).unwrap() },
-                Event::KeyDown { keycode: Some(Keycode::Left), .. } => { input_tx.send(InputEvent::LeftPressed).unwrap() },
-                Event::KeyUp  { keycode: Some(Keycode::Left), .. } => { input_tx.send(InputEvent::LeftReleased).unwrap() },
-                Event::KeyDown { keycode: Some(Keycode::Right), .. } => { input_tx.send(InputEvent::RightPressed).unwrap() },
-                Event::KeyUp  { keycode: Some(Keycode::Right), .. } => { input_tx.send(InputEvent::RightReleased).unwrap() },
-                Event::KeyDown { keycode: Some(Keycode::Down), .. } => { input_tx.send(InputEvent::DownPressed).unwrap() },
-                Event::KeyUp  { keycode: Some(Keycode::Down), .. } => { input_tx.send(InputEvent::DownReleased).unwrap() },
-                Event::KeyDown { keycode: Some(Keycode::Return), .. } => { input_tx.send(InputEvent::StartPressed).unwrap() },
-                Event::KeyUp  { keycode: Some(Keycode::Return), .. } => { input_tx.send(InputEvent::StartReleased).unwrap() },
-                Event::KeyDown { keycode: Some(Keycode::Backspace), .. } => { input_tx.send(InputEvent::SelectPressed).unwrap() },
-                Event::KeyUp  { keycode: Some(Keycode::Backspace), .. } => { input_tx.send(InputEvent::SelectReleased).unwrap() },*/
-                _ => {}
-            }
-        }
-
-        sdl2_imgui.prepare_frame(imgui.io_mut(), &main_window, &sdl_events.mouse_state());
-
-        let imgui_ui = imgui.frame();
-
-        Window::new(im_str!("Main Window"))
-        .size([300.0, 300.0], Condition::Always)
-        .build(&imgui_ui, || {
-            if let Some(menu) = imgui_ui.begin_menu(im_str!("Installed ROMs"), true) {
-                if all_roms.len() > 0 {
-
-                    for file in all_roms.iter() {
-                        let filename = ImString::new(file.file_name().into_string().unwrap());
-
-                        if MenuItem::new(&filename).build_with_ref(&imgui_ui, &mut false) { 
-
-                            if Path::new("Bootrom.gb").exists() {
-                                let game_window = sdl_video.window("Rusty Boi - Game Window", 160 * scale_factor as u32, 144 * scale_factor as u32)
-                                .position_centered().build().unwrap();
-                                let mut game_canvas = game_window.into_canvas().present_vsync().build().unwrap();
-                                game_canvas.set_scale(scale_factor, scale_factor).unwrap();
-                                init_emu(file);
-                            }
-                        };
-                    }
-                }
-                else {
-                    MenuItem::new(im_str!("No ROMs detected.")).build_with_ref(&imgui_ui, &mut false);
-                }
-                menu.end(&imgui_ui);
-            }
-            imgui_ui.separator();
-            if Path::new("Bootrom.gb").exists() {
-                imgui_ui.text_colored([0.0, 1.0, 0.0, 1.0], im_str!("Bootrom located, everything's ready"));
-            }
-            else {
-                imgui_ui.text_colored([1.0, 0.0, 0.0, 1.0], im_str!("Can't locate Bootrom!"));
-            }
-            imgui_ui.separator();
-            Slider::new(im_str!("Scale factor"), 1.0 ..= 10.0).display_format(im_str!("%.0f")).build(&imgui_ui, &mut scale_factor);
-        });
-
-        unsafe {
-            gl::ClearColor(0.2, 0.2, 0.2, 1.0);
-            gl::Clear(gl::COLOR_BUFFER_BIT);
-        }
-
-        sdl2_imgui.prepare_render(&imgui_ui, &main_window);
-        imgui_renderer.render(imgui_ui);
-        main_window.gl_swap_window();
-    }*/
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ fn main() {
                 imgui_ui.text_colored([1.0, 0.0, 0.0, 1.0], im_str!("Can't locate Bootrom!"));
             }
             imgui_ui.separator();
-            Slider::new(im_str!("Scale factor"), 1.0 ..= 50.0).display_format(im_str!("%.0f")).build(&imgui_ui, &mut scale_factor);
+            Slider::new(im_str!("Scale factor"), 1.0 ..= 10.0).display_format(im_str!("%.0f")).build(&imgui_ui, &mut scale_factor);
         });
 
         unsafe {

--- a/src/register.rs
+++ b/src/register.rs
@@ -157,7 +157,7 @@ impl PcTrait for Pc {
 impl CycleCounter for Cycles {
 
     fn add(&mut self, value: u16) {
-        self.value += value;
+        self.value = self.value.overflowing_add(value).0;
     }
 
     fn get(&self) -> u16 {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -204,6 +204,8 @@ fn ui_loop(sys: &mut ImguiSys, window: &video::Window, mouse_state: &sdl2::mouse
         }
         imgui_ui.separator();
 
+        // TODO: For some reason, there are still "?" on the title if it doesn't use
+        // all the bytes for the title.
         imgui_ui.text(format!("ROM Title: {}", &emu.header_data.title));
         imgui_ui.text(format!("Publisher: {}", &emu.header_data.publisher));
         imgui_ui.text(format!("Cart Type: {}", &emu.header_data.cart_type));
@@ -239,7 +241,9 @@ fn parse_header(file_path: &PathBuf) -> HeaderData {
     file.read(&mut header_buffer).unwrap();
 
     let game_title = String::from_utf8(header_buffer[308..323].to_vec()).unwrap().replace("?", " ");
-    println!("{}", game_title);
+
+    // TODO: This code can also be in 0144-0145 depending on the release
+    // date of the cartridge.
     let lic_code = match header_buffer[331] {
 
         0x00 => String::from("None"),
@@ -257,7 +261,8 @@ fn parse_header(file_path: &PathBuf) -> HeaderData {
         0x30 => String::from("Viacom"),
         0x31 => String::from("Nintendo"),
         0x32 => String::from("Bandai"),
-        0x33 => String::from("Ocean/Acclaim"),
+        // On 014B, it shows that the code is on 0144. On 0x144 it's Ocean/Acclaim
+        0x33 => String::from("New Licensee"),
         0x34 => String::from("Konami"),
         0x35 => String::from("Hector"),
         0x37 => String::from("Taito"),

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -112,6 +112,7 @@ pub fn init_renderer() {
                                 WindowEvent::Close => {
                                     emu_state.emu_running = false;
                                     if window_id == game_canvas.window().id() { 
+                                        input_tx.send(InputEvent::Quit).unwrap();
                                         break 'game_loop 
                                     } 
                                     else {
@@ -152,7 +153,10 @@ pub fn init_renderer() {
 
                 gpu::gpu_loop(&emulator_locks.cycles_arc, &mut gpu_state, &mut game_canvas, &emulator_locks.gpu);
                 if update_ui { ui_loop(&mut imgui_sys, &main_window, &sdl_events.mouse_state(), &all_roms, &mut emu_state) }
-                if !emu_state.emu_running { break 'game_loop }
+                if !emu_state.emu_running { 
+                    input_tx.send(InputEvent::Quit).unwrap();
+                    break 'game_loop;
+                }
             }
         }
         else {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -208,7 +208,7 @@ fn get_all_roms() -> Vec<fs::DirEntry> {
     init_dirs();
     let mut all_roms: Vec<fs::DirEntry> = Vec::new();
     let mut read_files: Vec<_> = fs::read_dir("roms").unwrap().map(|r| r.unwrap()).collect();
-    read_files.sort_by_key(|dir| dir.path());
+    read_files.sort_by_key(|dir| dir.path().to_str().unwrap().to_lowercase());
     
     for entry in read_files {
         

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -207,14 +207,15 @@ fn get_all_roms() -> Vec<fs::DirEntry> {
 
     init_dirs();
     let mut all_roms: Vec<fs::DirEntry> = Vec::new();
+    let mut read_files: Vec<_> = fs::read_dir("roms").unwrap().map(|r| r.unwrap()).collect();
+    read_files.sort_by_key(|dir| dir.path());
     
-    for entry in fs::read_dir("roms").unwrap() {
+    for entry in read_files {
         
-        let file = entry.unwrap();
-        let file_name = file.file_name().into_string().unwrap();
+        let file_name = entry.file_name().into_string().unwrap();
         
         if file_name.contains(".gb") {
-            all_roms.push(file);
+            all_roms.push(entry);
         }
     }
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,0 +1,194 @@
+use sdl2;
+use sdl2::event::Event;
+use sdl2::pixels::Color;
+
+use imgui::*;
+use imgui_sdl2;
+use imgui_opengl_renderer;
+
+use log::error;
+
+use std::io;
+use std::fs;
+use std::path::PathBuf;
+
+use super::gpu;
+use super::emulator;
+
+struct State {
+    pub emu_running: bool,
+    pub booted_rom: PathBuf,
+    pub game_scale: f32,
+}
+
+struct ImguiSys {
+    pub context: imgui::Context,
+    pub sdl_imgui: imgui_sdl2::ImguiSdl2,
+    pub renderer: imgui_opengl_renderer::Renderer,
+}
+
+pub fn init_renderer() {
+
+    let mut emu_state = State {
+        emu_running: false,
+        booted_rom: PathBuf::new(),
+        game_scale: 1.0,
+    };
+    
+    // Init SDL
+    let sdl_context = sdl2::init().unwrap();
+    let sdl_video = sdl_context.video().unwrap();
+    let mut sdl_events = sdl_context.event_pump().unwrap();
+    let main_window = sdl_video.window("Rusty Boi - Main Window", 600, 400).position_centered().opengl().build().unwrap();
+    let _gl_context = main_window.gl_create_context().expect("Failed to create OpenGL context");
+    gl::load_with(|s| sdl_video.gl_get_proc_address(s) as _);
+
+    // Init IMGUI
+    let mut imgui = imgui::Context::create();
+    let sdl2_imgui = imgui_sdl2::ImguiSdl2::new(&mut imgui, &main_window);
+    let imgui_renderer = imgui_opengl_renderer::Renderer::new(&mut imgui, |s| sdl_video.gl_get_proc_address(s) as _);
+    
+    let mut imgui_sys = ImguiSys {
+        context: imgui,
+        sdl_imgui: sdl2_imgui,
+        renderer: imgui_renderer
+    };
+
+    let all_roms = get_all_roms();
+
+    'render_loop: loop {
+
+        if emu_state.emu_running {
+
+            let mut gpu_state = gpu::init_gpu();
+            let game_window = sdl_video.window("Rusty Boi - Game Window", 160 * emu_state.game_scale as u32, 144 * emu_state.game_scale as u32)
+            .position_centered().build().unwrap();
+            let mut game_canvas = game_window.into_canvas().present_vsync().build().unwrap();
+
+            let emulator_locks = emulator::initialize(&emu_state.booted_rom);
+
+            game_canvas.set_scale(emu_state.game_scale, emu_state.game_scale).unwrap();
+            game_canvas.set_draw_color(Color::RGB(255, 255, 255));
+            game_canvas.clear();
+            game_canvas.present();
+
+            emulator::start_emulation(&emulator_locks);
+
+            'game_loop: loop {
+
+                for event in sdl_events.poll_iter() {
+
+                    imgui_sys.sdl_imgui.handle_event(&mut imgui_sys.context, &event);
+                    match event {
+                        Event::Quit {..} => { emu_state.emu_running = false }
+                        _ => {}
+                    }
+                }
+
+                gpu::gpu_loop(&emulator_locks.cycles_arc, &mut gpu_state, &mut game_canvas, &emulator_locks.gpu);
+                ui_loop(&mut imgui_sys, &main_window, &sdl_events.mouse_state(), &all_roms, &mut emu_state);
+                if !emu_state.emu_running {break 'game_loop}
+            }
+        }
+        else {
+
+            loop {
+
+                for event in sdl_events.poll_iter() {
+
+                    imgui_sys.sdl_imgui.handle_event(&mut imgui_sys.context, &event);
+                    match event {
+                        Event::Quit {..} => { break 'render_loop }
+                        _ => {}
+                    }
+                }
+                ui_loop(&mut imgui_sys, &main_window, &sdl_events.mouse_state(), &all_roms, &mut emu_state);
+                if emu_state.emu_running {break;}
+            }
+        }
+    }
+
+}
+
+fn ui_loop(sys: &mut ImguiSys, window: &sdl2::video::Window, mouse_state: &sdl2::mouse::MouseState, all_roms: &Vec<fs::DirEntry>, emu: &mut State) {
+
+    sys.sdl_imgui.prepare_frame(sys.context.io_mut(), window, mouse_state);
+    let imgui_ui = sys.context.frame();
+
+    Window::new(im_str!("Rusty Boi - Main Window"))
+    .size([300.0, 350.0], Condition::Always)
+    .build(&imgui_ui, || {
+        if let Some(menu) = imgui_ui.begin_menu(im_str!("Detected ROMs"), true) {
+            if all_roms.len() > 0 && !emu.emu_running {
+
+                for file in all_roms.iter() {
+                    let filename = ImString::new(file.file_name().into_string().unwrap());
+
+                    if MenuItem::new(&filename).build_with_ref(&imgui_ui, &mut false) { 
+
+                        if PathBuf::from("Bootrom.gb").exists() && !emu.emu_running {
+                            emu.emu_running = true;
+                            emu.booted_rom = file.path();
+                        }
+                    };
+                }
+            }
+            else {
+                MenuItem::new(im_str!("No ROMs detected.")).build_with_ref(&imgui_ui, &mut false);
+            }
+            menu.end(&imgui_ui);
+        }
+        imgui_ui.separator();
+        if PathBuf::from("Bootrom.gb").exists() {
+            imgui_ui.text_colored([0.0, 1.0, 0.0, 1.0], im_str!("Bootrom located, everything's ready"));
+        }
+        else {
+            imgui_ui.text_colored([1.0, 0.0, 0.0, 1.0], im_str!("Can't locate Bootrom!"));
+        }
+        imgui_ui.separator();
+        Slider::new(im_str!("Scale factor"), 1.0 ..= 10.0).display_format(im_str!("%.0f")).build(&imgui_ui, &mut emu.game_scale);
+    });
+
+    unsafe {
+        gl::ClearColor(0.2, 0.2, 0.2, 1.0);
+        gl::Clear(gl::COLOR_BUFFER_BIT);
+    }
+
+    sys.sdl_imgui.prepare_render(&imgui_ui, &window);
+    sys.renderer.render(imgui_ui);
+    window.gl_swap_window();
+}
+
+fn get_all_roms() -> Vec<fs::DirEntry> {
+
+    init_dirs();
+    let mut all_roms: Vec<fs::DirEntry> = Vec::new();
+    
+    for entry in fs::read_dir("roms").unwrap() {
+        
+        let file = entry.unwrap();
+        let file_name = file.file_name().into_string().unwrap();
+        
+        if file_name.contains(".gb") {
+            all_roms.push(file);
+        }
+    }
+
+    all_roms
+}
+
+fn init_dirs() {
+
+    let roms_dir = fs::create_dir("roms");
+    match roms_dir {
+
+        Ok(_result) => {},
+        Err(error) => {
+            match error.kind() {
+                io::ErrorKind::AlreadyExists => {},
+                io::ErrorKind::PermissionDenied => {error!("Failed to create ROMs directory: Permission Denied")},
+                _ => {},
+            }
+        }
+    }
+}

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -12,7 +12,9 @@ use imgui_opengl_renderer;
 use log::error;
 
 use std::io;
+use std::io::Read;
 use std::fs;
+use std::fs::File;
 use std::sync::mpsc;
 use std::path::PathBuf;
 
@@ -24,6 +26,7 @@ struct State {
     pub emu_running: bool,
     pub booted_rom: PathBuf,
     pub game_scale: f32,
+    pub header_data: HeaderData,
 }
 
 struct ImguiSys {
@@ -32,12 +35,27 @@ struct ImguiSys {
     pub renderer: imgui_opengl_renderer::Renderer,
 }
 
+struct HeaderData {
+    title: String,
+    publisher: String,
+    cart_type: String,
+    rom_size: String,
+    ram_size: String,
+}
+
 pub fn init_renderer() {
 
     let mut emu_state = State {
         emu_running: false,
         booted_rom: PathBuf::new(),
         game_scale: 1.0,
+        header_data: HeaderData {
+            title: String::from(""),
+            publisher: String::from(""),
+            cart_type: String::from(""),
+            rom_size: String::from(""),
+            ram_size: String::from(""),
+        }
     };
     
     // Init SDL
@@ -171,11 +189,12 @@ fn ui_loop(sys: &mut ImguiSys, window: &video::Window, mouse_state: &sdl2::mouse
 
                     if MenuItem::new(&filename).build_with_ref(&imgui_ui, &mut false) { 
 
+                        emu.header_data = parse_header(&file.path());
                         if PathBuf::from("Bootrom.gb").exists() {
                             emu.emu_running = true;
                             emu.booted_rom = file.path();
                         }
-                    };
+                    }
                 }
             }
             else {
@@ -183,6 +202,14 @@ fn ui_loop(sys: &mut ImguiSys, window: &video::Window, mouse_state: &sdl2::mouse
             }
             menu.end(&imgui_ui);
         }
+        imgui_ui.separator();
+
+        imgui_ui.text(format!("ROM Title: {}", &emu.header_data.title));
+        imgui_ui.text(format!("Publisher: {}", &emu.header_data.publisher));
+        imgui_ui.text(format!("Cart Type: {}", &emu.header_data.cart_type));
+        imgui_ui.text(format!("ROM Size: {}", &emu.header_data.rom_size));
+        imgui_ui.text(format!("RAM Size: {}", &emu.header_data.ram_size));
+
         imgui_ui.separator();
         if PathBuf::from("Bootrom.gb").exists() {
             imgui_ui.text_colored([0.0, 1.0, 0.0, 1.0], im_str!("Bootrom located, everything's ready"));
@@ -201,6 +228,122 @@ fn ui_loop(sys: &mut ImguiSys, window: &video::Window, mouse_state: &sdl2::mouse
 
     sys.renderer.render(imgui_ui);
     window.gl_swap_window();
+}
+
+
+fn parse_header(file_path: &PathBuf) -> HeaderData {
+
+    let header: HeaderData;
+    let mut file = File::open(file_path).unwrap();
+    let mut header_buffer = [0; 335];
+    file.read(&mut header_buffer).unwrap();
+
+    let game_title = String::from_utf8(header_buffer[308..323].to_vec()).unwrap().replace("?", " ");
+    println!("{}", game_title);
+    let lic_code = match header_buffer[331] {
+
+        0x00 => String::from("None"),
+        0x01 => String::from("Nintendo R&D 1"),
+        0x08 => String::from("Capcom"),
+        0x13 => String::from("Electronic Arts"),
+        0x18 => String::from("Hudson Soft"),
+        0x19 => String::from("b-ai"),
+        0x20 => String::from("kss"),
+        0x22 => String::from("pow"),
+        0x24 => String::from("PCM Complete"),
+        0x25 => String::from("san-z"),
+        0x28 => String::from("Kemco Japan"),
+        0x29 => String::from("seta"),
+        0x30 => String::from("Viacom"),
+        0x31 => String::from("Nintendo"),
+        0x32 => String::from("Bandai"),
+        0x33 => String::from("Ocean/Acclaim"),
+        0x34 => String::from("Konami"),
+        0x35 => String::from("Hector"),
+        0x37 => String::from("Taito"),
+        0x38 => String::from("Hudson"),
+        0x39 => String::from("Banpresto"),
+        0x41 => String::from("Ubi Soft"),
+        0x42 => String::from("Atlus"),
+        0x44 => String::from("Malibu"),
+        0x46 => String::from("angel"),
+        0x47 => String::from("Bullet-Proof"),
+        0x49 => String::from("irem"),
+        0x50 => String::from("Absolute"),
+        0x51 => String::from("Acclaim"),
+        0x52 => String::from("Activision"),
+        0x53 => String::from("American sammy"),
+        0x54 => String::from("Konami"),
+        0x55 => String::from("Hi tech entertainment"),
+        0x56 => String::from("LJN"),
+        0x57 => String::from("Matchbox"),
+        0x58 => String::from("Mattel"),
+        0x59 => String::from("Milton Bradley"),
+        0x60 => String::from("Titus"),
+        0x61 => String::from("Virgin"),
+        0x64 => String::from("LucasArts"),
+        0x67 => String::from("Ocean"),
+        0x69 => String::from("Electronic Arts"),
+        0x70 => String::from("Infogrames"),
+        0x71 => String::from("Interplay"),
+        0x72 => String::from("Broderbund"),
+        0x73 => String::from("sculptured"),
+        0x75 => String::from("sci"),
+        0x78 => String::from("THQ"),
+        0x79 => String::from("Accolade"),
+        0x80 => String::from("misawa"),
+        0x83 => String::from("Iozc"),
+        0x86 => String::from("tokuma shoten i*"),
+        0x87 => String::from("tsukuda ori*"),
+        0x91 => String::from("Chunsoft"),
+        0x92 => String::from("Video system"),
+        0x93 => String::from("Ocean/Acclaim"),
+        0x95 => String::from("Varie"),
+        0x96 => String::from("Yonezawa/s'pal"),
+        0x97 => String::from("Kaneko"),
+        0x99 => String::from("Pack in soft"),
+        0xA4 => String::from("Konami (Yu-Gi-Oh!)"),
+        _ => String::from("Unknown"),
+    };
+
+    let mbc_type = match header_buffer[327] {
+        0x00 => String::from("No MBC"),
+        0x01 => String::from("MBC1"),
+        0x02 => String::from("MBC1 with RAM"),
+        0x03 => String::from("MBC1 with RAM and battery"),
+        0x05 => String::from("MBC2"),
+        0x06 => String::from("MBC2 with battery"),
+        0x08 => String::from("ROM with RAM"),
+        0x09 => String::from("ROM with RAM and battery"),
+        0x0B => String::from("MMM01"),
+        0x0C => String::from("MMM01 with RAM"),
+        0x0D => String::from("MMM01 with RAM and battery"),
+        0x0F => String::from("MBC3 with timer and battery"),
+        0x11 => String::from("MBC3"),
+        0x12 => String::from("MBC3 with RAM"),
+        0x13 => String::from("MBC3 with RAM and battery"),
+        _ => String::from("Unknown"),
+    };
+
+    let rom_size = format!("{}KB", 32 << header_buffer[328]);
+    let ram_size = match header_buffer[329] {
+        0x00 => String::from("None"),
+        0x01 => String::from("2KB"),
+        0x02 => String::from("8KB"),
+        0x03 => String::from("32KB"),
+        0x04 => String::from("128KB"),
+        0x05 => String::from("64KB"),
+        _ => String::from("Unknown"),
+    };
+
+    header = HeaderData {
+        title: game_title,
+        publisher: lic_code,
+        cart_type: mbc_type,
+        rom_size: rom_size,
+        ram_size: ram_size,
+    };
+    header
 }
 
 fn get_all_roms() -> Vec<fs::DirEntry> {


### PR DESCRIPTION
Initial work on proper user interface for the emu.

When the emulator is opened you now get a main window powered by imgui+sdl that lets you select, boot, and get some info from ROMs placed in the roms folder, next to the executable (or the project's root if running with `cargo run`). The Bootrom needs to be placed next to the binary as well for the emu to work.

This also lays the foundation for some built-in tools, like a simple debugger, or memory viewer/editor.


**Current issues:**
-The game window and the main one "overlap" if they use the same rendering backend (like OpenGL), which causes that commands meant for one window also are applied to the other one (like gl::Clear() on the main window also clears the game window). To work around this, the game window now uses Vulkan to render, while the main one was kept in OpenGL.

-The `gl::Clear()` function seems to wait for VSync, causing a ~16ms delay to finish the UI update function. This causes the emu's GPU to take a lot more time to finish drawing frames, which causes a slideshow instead of a game to be displayed. Since I couldn't find a way to disable that wait, the main window is only updated when it's on focus.

~~-The CPU thread may continue execution after closing the game window.~~ Fixed